### PR TITLE
노준영 - context/api - 코드리뷰

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,6 @@ import React from 'react';
 import { RouterProvider } from 'react-router-dom';
 import router from './router';
 import { GlobalStyle } from './GlobalStyle';
-
-// const StyledApp = styled.div`
-//   color: ${palette.text};
-// `;
-
 function App() {
   return (
     <>

--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -5,7 +5,6 @@ import { createGlobalStyle } from 'styled-components';
 export const GlobalStyle = createGlobalStyle`
 
 #root {
-  background-color: red;
   width: 100%;
   max-width: 1024px;
   padding: 0 16px;

--- a/src/apis/issues.ts
+++ b/src/apis/issues.ts
@@ -49,10 +49,6 @@ instance.interceptors.response.use(
     return response;
   },
   (error) => {
-    const { data } = error.response;
-    if (!data.message) {
-      return Promise.reject(new Error('알 수 없는 에러가 발생했습니다.'));
-    }
-    return Promise.reject(new Error(data.message));
+    return Promise.reject(error);
   },
 );

--- a/src/apis/issues.ts
+++ b/src/apis/issues.ts
@@ -1,0 +1,58 @@
+import { Dispatch } from 'react';
+import axios from 'axios';
+import { IssueListAction } from '../context/IssueListProvider';
+import { IssueDetailAction } from '../context/IssueDetailProvider';
+
+const instance = axios.create({
+  baseURL: `${process.env.REACT_APP_GITHUB_API_ENDPOINT}`,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export async function getIssueList(dispatch: Dispatch<IssueListAction>, page: number) {
+  dispatch({ type: 'SET_LOADING' });
+  try {
+    const response = await instance.get(`issues?sort=comments&per_page=10&page=${page}`);
+    dispatch({ type: 'GET_ISSUE_LIST', data: response.data });
+  } catch (error) {
+    Promise.reject(error);
+  }
+}
+
+export async function getIssueDetail(dispatch: Dispatch<IssueDetailAction>, id: number) {
+  dispatch({ type: 'SET_LOADING' });
+  try {
+    const response = await instance.get(`issues/${id}`);
+    dispatch({ type: 'GET_ISSUE_DETAIL', data: response.data });
+  } catch (error) {
+    Promise.reject(error);
+  }
+}
+
+instance.interceptors.request.use(
+  (config) => {
+    const accessToken = process.env.REACT_APP_ACCESS_TOKEN;
+    const newConfig = config;
+    if (accessToken !== undefined) {
+      newConfig.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return newConfig;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
+
+instance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    const { data } = error.response;
+    if (!data.message) {
+      return Promise.reject(new Error('알 수 없는 에러가 발생했습니다.'));
+    }
+    return Promise.reject(new Error(data.message));
+  },
+);

--- a/src/context/IssueDetailProvider.tsx
+++ b/src/context/IssueDetailProvider.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useReducer, Dispatch } from 'react';
+import { IssueDetail } from '../types/IssueDetailType';
+
+type IssueDetailState = {
+  loading: boolean;
+  data?: IssueDetail;
+};
+
+export type IssueDetailAction = {
+  type: 'SET_LOADING' | 'GET_ISSUE_DETAIL';
+  data?: IssueDetail;
+};
+
+type IssueDetailProviderProps = {
+  children: React.ReactNode;
+};
+
+const initialState: IssueDetailState = {
+  loading: false,
+  data: { title: '', number: 0, created_at: '', comments: 0, user: { login: '' }, body: '' },
+};
+
+function issueDetailReducer(state: IssueDetailState, action: IssueDetailAction): IssueDetailState {
+  switch (action.type) {
+    case 'SET_LOADING':
+      return {
+        ...state,
+        loading: true,
+      };
+    case 'GET_ISSUE_DETAIL':
+      return {
+        ...state,
+        data: action.data,
+        loading: false,
+      };
+    default:
+      throw new Error(`알 수 없는 Action 타입입니다: ${action.type}`);
+  }
+}
+
+export const IssueDetailStateContext = createContext(initialState);
+export const IssueDetailDispatchContext = createContext<Dispatch<IssueDetailAction> | null>(null);
+
+export function IssueDetailProvider({ children }: IssueDetailProviderProps) {
+  const [state, dispatch] = useReducer(issueDetailReducer, initialState);
+  return (
+    <IssueDetailStateContext.Provider value={state}>
+      <IssueDetailDispatchContext.Provider value={dispatch}>
+        {children}
+      </IssueDetailDispatchContext.Provider>
+    </IssueDetailStateContext.Provider>
+  );
+}

--- a/src/context/IssueListProvider.tsx
+++ b/src/context/IssueListProvider.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useReducer, Dispatch } from 'react';
+import { IssueList } from '../types/IssueListType';
+
+type IssueListState = {
+  loading: boolean;
+  data?: IssueList;
+};
+
+export type IssueListAction = {
+  type: 'SET_LOADING' | 'GET_ISSUE_LIST';
+  data?: IssueList;
+};
+
+type IssueListProviderProps = {
+  children: React.ReactNode;
+};
+
+const initialState: IssueListState = {
+  loading: false,
+  data: [],
+};
+
+function issueListReducer(state: IssueListState, action: IssueListAction): IssueListState {
+  switch (action.type) {
+    case 'SET_LOADING':
+      return {
+        ...state,
+        loading: true,
+      };
+    case 'GET_ISSUE_LIST':
+      return {
+        ...state,
+        data: action.data ? state.data?.concat(action.data) : state.data,
+        loading: false,
+      };
+    default:
+      throw new Error(`알 수 없는 Action 타입입니다: ${action.type}`);
+  }
+}
+
+export const IssueListStateContext = createContext(initialState);
+export const IssueListDispatchContext = createContext<Dispatch<IssueListAction> | null>(null);
+
+export function IssueListProvider({ children }: IssueListProviderProps) {
+  const [state, dispatch] = useReducer(issueListReducer, initialState);
+  return (
+    <IssueListStateContext.Provider value={state}>
+      <IssueListDispatchContext.Provider value={dispatch}>
+        {children}
+      </IssueListDispatchContext.Provider>
+    </IssueListStateContext.Provider>
+  );
+}

--- a/src/hooks/useIssueDetailDispatch.ts
+++ b/src/hooks/useIssueDetailDispatch.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { IssueDetailDispatchContext } from '../context/IssueDetailProvider';
+
+export default function useIssueDetailDispatch() {
+  const state = useContext(IssueDetailDispatchContext);
+  if (!state) {
+    throw new Error('IssueDetailProvider가 존재하지 않습니다.');
+  }
+  return state;
+}

--- a/src/hooks/useIssueDetailState.ts
+++ b/src/hooks/useIssueDetailState.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { IssueDetailStateContext } from '../context/IssueDetailProvider';
+
+export default function useIssueDetailState() {
+  const state = useContext(IssueDetailStateContext);
+  if (!state) {
+    throw new Error('IssueDetailProvider가 존재하지 않습니다.');
+  }
+  return state;
+}

--- a/src/hooks/useIssueListDispatch.ts
+++ b/src/hooks/useIssueListDispatch.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { IssueListDispatchContext } from '../context/IssueListProvider';
+
+export default function useIssueListDispatch() {
+  const state = useContext(IssueListDispatchContext);
+  if (!state) {
+    throw new Error('IssueListProvider가 존재하지 않습니다.');
+  }
+  return state;
+}

--- a/src/hooks/useIssueListState.ts
+++ b/src/hooks/useIssueListState.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { IssueListStateContext } from '../context/IssueListProvider';
+
+export default function useIssueListState() {
+  const state = useContext(IssueListStateContext);
+  if (!state) {
+    throw new Error('IssueListProvider가 존재하지 않습니다.');
+  }
+  return state;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { IssueListProvider } from './context/IssueListProvider';
+import { IssueDetailProvider } from './context/IssueDetailProvider';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <IssueListProvider>
+      <IssueDetailProvider>
+        <App />
+      </IssueDetailProvider>
+    </IssueListProvider>
   </React.StrictMode>,
 );

--- a/src/types/IssueDetailType.ts
+++ b/src/types/IssueDetailType.ts
@@ -1,0 +1,12 @@
+export interface IssueDetail {
+  title: string;
+  number: number;
+  created_at: string;
+  comments: number;
+  user: User;
+  body: string;
+}
+
+export interface User {
+  login: string;
+}

--- a/src/types/IssueListType.ts
+++ b/src/types/IssueListType.ts
@@ -1,0 +1,13 @@
+export interface Issue {
+  title: string;
+  number: number;
+  created_at: string;
+  comments: number;
+  user: User;
+}
+
+export interface User {
+  login: string;
+}
+
+export type IssueList = Issue[];


### PR DESCRIPTION
## 개요

Issue목록과 Issue 상세를 각각 다른 Context로 다루도록 개발하였습니다.
Context사용과 API연동은 [벨로퍼트](https://react.vlpt.us/integrate-api/05-using-with-context.html)의 방법을 참고하였습니다.

<!-- 작업의 목적과 어떤 작업인지 간단하게 기술 -->

## 작업내용

- `context 폴더`
    - `IssueListProvider`와 `IssueDetailProvider`를 생성하였습니다.
        - 기본적으로 `useReducer`와 `dispatch`를 활용하여 작업하였습니다. 
        - reducer내에서 로딩 처리와 fetch처리를 할 수 있게 구성하였습니다
        - api에서는 `dispatch`를 호출하여 로딩처리와 fetch를 진행합니다.
        - 각 context는 issue상세와 issue목록을 가집니다.
- `hooks 폴더`
    - 지난과제에서 toast context를 쉽게 꺼내기 위해 `custom hook`을 사용한 것 처럼, context 상태와 dispatch를 쉽게 꺼내기 위해 `state`와 `dispatch`에 대해서 custom hook을 설계하였습니다.
- `types 폴더`
    - 도메인 별로 나누어 상태관리에 필요한 interface를 설계하여 보관하였습니다.
- `api 폴더`
    -  axios instance와 axios interceptor를 사용하였습니다.
    - 각 api 호출 시작시, loading dispatch를 걸어줍니다
    - api응답 완료시, data return과 함께 loading 상태를 false로 변경시킵니다.
 
## 사용법

- 페이지/컴포넌트단에서는 당연하게도 context외의 상태에 접근할 필요가 없습니다(page정도만 따로 관리하면 되겠네요)
- custom hook을 사용하여 issue 상태를 꺼내서 데이터/로딩 에 접근하면 됩니다.
```typescript
const state = useIssueListState();
const { data: issues, loading } = state;
```
- api호출시에는 dispatch를 custom hook으로 빼낸다음, page나 id와 함께 넘겨주면 됩니다.
```typescript
const getDetailIssue = async (dispatch: Dispatch<IssueDetailAction>, id: number) => {
  await getIssueDetail(dispatch, id);
};
getDetailIssue(dispatch, 13991);
```
