### PR TITLE
정범수 - 스크롤 로직 변경사항 -  코드리뷰

### DIFF
--- a/src/apis/issues.ts
+++ b/src/apis/issues.ts
@@ -26,4 +26,11 @@ const getIssue: (pathParam: GetIssuePathParam) => Promise<IssueSchema> = async (
   return res.data as IssueSchema;
 };
 
-export { getIssueList, getIssue };
+const getIssueCount = async (pathParam: GetIssuesPathParam): Promise<number> => {
+  const { owner, repo } = pathParam;
+  const res = await instance.get(`/repos/${owner}/${repo}`);
+
+  return res.data.open_issues_count;
+};
+
+export { getIssueList, getIssue, getIssueCount };

--- a/src/hooks/useIssues.ts
+++ b/src/hooks/useIssues.ts
@@ -33,8 +33,6 @@ export function useIssues() {
     const res = await getIssueList(pathParam, queryParam);
     setIssueList(res);
     setIsLoading(false);
-
-    console.log('fetchIssue');
   };
 
   const fetchMoreIssues = async () => {
@@ -49,8 +47,6 @@ export function useIssues() {
     const NEXT_PAGE = Math.floor(issueList.length / PER_PAGE) + 1;
 
     const res = await getIssueList(pathParam, { ...queryParam, page: NEXT_PAGE });
-
-    console.log('fetchMoreIssue:', issueList.length, NEXT_PAGE, issueList, res);
 
     if (res.length === 0) {
       setIsEnd(true);

--- a/src/hooks/useIssues.ts
+++ b/src/hooks/useIssues.ts
@@ -1,6 +1,6 @@
 import { useContext, useState } from 'react';
 import { IssuesContext } from '../contexts/IssuesContextProvider';
-import { getIssueList } from '../apis/issues';
+import { getIssueCount, getIssueList } from '../apis/issues';
 import { GetIssuesQueryParam } from '../types/issuesApi';
 import pathParam from '../constant/pathParam';
 
@@ -16,24 +16,61 @@ export function useIssues() {
   if (!context) throw new Error('IssuesContextProvider를 찾을 수 없습니다!');
 
   const { issueList, setIssueList } = context;
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEnd, setIsEnd] = useState(false);
+  const [countLoading, setCountLoading] = useState(false);
+  const [count, setCount] = useState(0);
+
+  const fetchIssueCount = async () => {
+    setCountLoading(true);
+    const res = await getIssueCount(pathParam);
+    setCount(res);
+    setCountLoading(false);
+  };
 
   const fetchIssues = async () => {
     setIsLoading(true);
     const res = await getIssueList(pathParam, queryParam);
     setIssueList(res);
     setIsLoading(false);
+
+    console.log('fetchIssue');
   };
 
   const fetchMoreIssues = async () => {
+    setIsLoading(true);
+
+    if (count < 10) {
+      setIsEnd(true);
+      setIsLoading(false);
+      return;
+    }
+
     const NEXT_PAGE = Math.floor(issueList.length / PER_PAGE) + 1;
 
-    setIsLoading(true);
     const res = await getIssueList(pathParam, { ...queryParam, page: NEXT_PAGE });
+
+    console.log('fetchMoreIssue:', issueList.length, NEXT_PAGE, issueList, res);
+
+    if (res.length === 0) {
+      setIsEnd(true);
+      setIsLoading(false);
+      return;
+    }
+
     setIssueList([...issueList, ...res]);
 
     setIsLoading(false);
   };
 
-  return { issueList, fetchIssues, fetchMoreIssues, isLoading };
+  return {
+    issueList,
+    isEnd,
+    count,
+    countLoading,
+    fetchIssueCount,
+    fetchIssues,
+    fetchMoreIssues,
+    isLoading,
+  };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,8 +3,4 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+root.render(<App />);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,4 +3,8 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-root.render(<App />);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/pages/IssueList.tsx
+++ b/src/pages/IssueList.tsx
@@ -9,7 +9,15 @@ import LoadSpinner from '../components/LoadSpinner';
 import styled from 'styled-components';
 
 function IssueList() {
-  const { issueList: data, fetchIssues, fetchMoreIssues, isLoading } = useIssues();
+  const {
+    issueList: data,
+    isEnd,
+    countLoading,
+    fetchIssues,
+    fetchMoreIssues,
+    fetchIssueCount,
+    isLoading,
+  } = useIssues();
   const target = useRef(null);
   const [page, setPage] = useState(1);
 
@@ -18,13 +26,16 @@ function IssueList() {
   });
 
   useEffect(() => {
+    fetchIssueCount();
     fetchIssues();
     setPage(page + 1);
     observe(target.current);
   }, []);
 
   useEffect(() => {
-    if (!isLoading) fetchMoreIssues();
+    if (!countLoading && !isLoading && !isEnd) {
+      fetchMoreIssues();
+    }
   }, [page]);
 
   return (


### PR DESCRIPTION
## 개요
- 무한스크롤시 총 페이지 아이템 개수보다 넘치는 페이지를 요청했을시 계속 로딩처리되는점 해결
- 무한스크롤시 총 페이지 개수가 10개 미만일때 1페이지의 데이터를 추가하는 이슈 해결
<!-- 작업의 목적과 어떤 작업인지 간단하게 기술 -->

## 작업내용
`isEnd` 라는 상태를 추가해주어 마지막페이지일경우 api요청을안하게 변경했습니다
`/repo/facebook/react` api를 새로 작성해 총 issue 개수를 가지고와 10개미만일경우는 스크롤시 추가 API를 실행하지 않게 변경했습니다
